### PR TITLE
Fix 'create' tests

### DIFF
--- a/src/functions/create/handler.ts
+++ b/src/functions/create/handler.ts
@@ -16,7 +16,7 @@ const create: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (event) 
   //check link
   if (!validRegistrationTime) {
     return {
-      statusCode: 403,
+      statusCode: 400,
       body: JSON.stringify({
         statusCode: 400,
         message: 'Registration is closed!',

--- a/tests/create.test.ts
+++ b/tests/create.test.ts
@@ -1,11 +1,12 @@
 import { main } from '../src/functions/create/handler';
 import { createEvent, mockContext } from './helper';
 
-const bcrypt = require('bcryptjs');
+import * as bcrypt from 'bcryptjs';
 jest.mock('bcryptjs');
 
 //mock the db route
 jest.mock('../src/util', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   MongoDB: {
     getInstance: jest.fn().mockReturnValue({
       connect: jest.fn(),
@@ -21,7 +22,7 @@ jest.mock('../src/util', () => ({
 
 jest.mock('../src/config.ts', () => ({
   registrationStart: '06/02/2024',
-  registrationEnd: '06/30/2024',
+  registrationEnd: '12/31/2099',
 }));
 
 describe('Create endpoint', () => {
@@ -30,7 +31,7 @@ describe('Create endpoint', () => {
 
     const mockCallback = jest.fn();
 
-    bcrypt.hash.mockResolvedValue('hashedPassword');
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashedPassword');
 
     const res = await main(mockEvent, mockContext, mockCallback);
     expect(res.statusCode).toBe(400);
@@ -41,7 +42,7 @@ describe('Create endpoint', () => {
 
     const mockCallback = jest.fn();
 
-    bcrypt.hash.mockResolvedValue('hashedPassword');
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashedPassword');
     const res = await main(mockEvent, mockContext, mockCallback);
 
     expect(res.statusCode).toBe(200);
@@ -49,13 +50,13 @@ describe('Create endpoint', () => {
   });
   it('Registration time has passed', async () => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('07/01/2024'));
+    jest.setSystemTime(new Date('01/01/2100'));
 
     const mockEvent = createEvent({ email: 'testEmail@gmail.com', password: 'testPassword123' }, '/create', 'POST');
     const mockCallback = jest.fn();
     const res = await main(mockEvent, mockContext, mockCallback);
 
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).message).toBe('Registration is closed!');
   });
 });


### PR DESCRIPTION
**SUMMARY**
 - Adjusted the registration end dates in the test so they would always be valid (or for another 76 years..)
 - Fixed statusCode so they are consistent across
 - Fixed eslint errors