### PR TITLE
cd: build .env.vault based on stage

### DIFF
--- a/.env.vault
+++ b/.env.vault
@@ -1,7 +1,0 @@
-#/-------------------.env.vault---------------------/
-#/         cloud-agnostic vaulting standard         /
-#/   [how it works](https://dotenv.org/env-vault)   /
-#/--------------------------------------------------/
-
-# development
-DOTENV_VAULT_DEVELOPMENT="fyiUAhw+idlDgGC/pKIMzuLNoLWN02LPaWhVVryzTzeFjOvYJaDtnHZwRJ6ddGD11aAMeDzbKJfDgKuBzMAsXiNTVNhdJjJGRUB7IU0MEsDRcjzLIcKdAh/BPeU9HvueezL6xDobYTxsD0NWjbcqR8u/vWwYWYMyHxBUnQE6XB7JtiFtPIY/j+8+uAxNRBFotmRRn/vkF8OEm0MnLsCKnlBDsLHoUwdojuYEaAV+A6ZNgFE7YnvRe7NLA653cDNZUZnlRBLMnAiUCxLtoNg8+niwFV0y/3AeU7UwjdtQ4RzR03SqyuorqyEBv6eoZ0I33FD6JYy/3+njkLyMqQN9aVBPsPkPy9UV/msew0Lt1ihsEc56VqbW8MTL36Hri/FrmkN1ttTVbU8f9Hg1xNjse9R0lC6if9tzhC6BHTYVCjDPu/0hF5Ao5EcYke19iHx+57Omdf+F2fm/0YJKo+KA5rHXy2uHeexwN9YSYxrX9arMWX5V9VTCejLF4Y/HcNvVMLrFjC3D6qt+iYJ0uZfDPXvV9reasg+u5ys/VkuJnj7mant5kxLnsizXVu2fbegH7mGVwpuNi0IphmU3eQHvun/Vme8buDe9GBzcne8AXDPd8lL0NZL8UUya5kijDDe5R+Cx8hHMKy9CH15PzmtQMc8yAz57AwJjE8ltHCRVeewu+jRiSjr+GTXQ0GUdhpJsJsU2VnbdiDGTwIRvHGYl/LxL3TKxqvrFeTAH3HmzvJ46dQ=="

--- a/.env.vault.dev
+++ b/.env.vault.dev
@@ -1,0 +1,7 @@
+#/-------------------.env.vault---------------------/
+#/         cloud-agnostic vaulting standard         /
+#/   [how it works](https://dotenv.org/env-vault)   /
+#/--------------------------------------------------/
+
+# development
+DOTENV_VAULT_DEVELOPMENT="7cDIHva2UEmdyd1PTA58L6dtKtM7DZpRtsFB49OcVLFnFvyX1M7DpQnv4W7qf5Pv9OusYxJOMWKxV6pf5PcGBMNvvGdmSAAAKfI4jdUEk7FgZBv60hFZOQqi+xfSNgjdwg+OoEnH6ggYlLP8dNCfIUwtlbZqPOQxL6sT/2sNr9TNwyAe+ml1UEn5KJ0iCbP2Dl7XZ/uVb8M9pGMmn+8KKNxRH6V14WgfyrORNcbmzymCx29T4By1tE9eN3aHi9zCZir+rlj7jFTCSk8KEbvY/hvBy+tn1cUikLDrTNqdP+U1EFNPzoRdS8EQNEqn7LDmvN3J0711mavvS658LfrJOUZQP73j3mx2IfHx+fs+Rdcx6P89+8518TZJZtVHPujNDmR7lCGbCOOZSaKBVbqYV6fzLpdDSWEWHqhx9gQWjU7FaRk5IjPdUdPPsE3qmIWUaTy/CHEEkEHI8a51g4IWxUxye5cZ6cSkJheH547UwL/7DdYWqAMdRz5WbkKh8SskCjIiiIDT+CD7zSLBmR0MCIDDafUYlSfqdsulFsZbHMijzmzDwIL7zbD37ZZ3Qx7ms0/cMu6VKQN7veYYD8OK6ZUKYwmY91rKzOth3kfkCRCRFAGpAuImDozXDAc6am5Y0odHC3zK0g2EJjXdWbtJ3bAo2YeU5IFsY1VX0BaQuriKnvtCU9qgzTISlREGIlqKN8Q7GOCL6w9t8zZIYgOoxaeZRG1kqre7LsOM6Nk9J0h+ZyHTw2lqF/5jiy8ylebCmItgyvo3MA=="

--- a/.env.vault.prod
+++ b/.env.vault.prod
@@ -1,0 +1,7 @@
+#/-------------------.env.vault---------------------/
+#/         cloud-agnostic vaulting standard         /
+#/   [how it works](https://dotenv.org/env-vault)   /
+#/--------------------------------------------------/
+
+# development
+DOTENV_VAULT_DEVELOPMENT="kdFvio61ngR3foQ2m8b/oY+R3vPpRaUXQxw5nGEIMp9K0oFnUYjNmuamN0hb+Prhc/fdByS/mfgbffhX6XT+FKf6wmrx5uPO0AuoTh97AFerYairMB/FJKCeDgUy4vExiXktJtcoeUiBTh/L2JRWcecHZ2pEIybiGSEMl/A846WfVa7tpcQI8gUzfQLyr9l+fbCVjhi96BBh7q5abTju0Yc76Po6v+syldJtV8cxnVvh6BdkOjKpr+TmN6avwcBM6qYLN81D/N15Qjkr/B5EmxpWtsCDaagmKcfvFLW/W9DvFuCQEPwZt3KIPV4wCaa7I5U4FubML+GP7zm59V33Lp8tilUN41OneJp/6wKy6WSOowQDxxERTTI6omnxe2OJfaVUwOAw8I4Ly2HQnz6auTe4a2PARIr/4sltMB7n/CeSi4GSGzWctvrNGlZe4Ym5qqwBGjb9C1fIf/XKfzbpVOqaaW1YnpcpZCTeE50gvKVuNRaAvqDYZjtBjy/JZFhlTXl8ox/3WkPrttGDnLPdTNi701PmEs4EITsOUTNOpCoqdCAQu00M905kZYpUdyriiZh/apTYHPMzLrFMI6RGFfhTwcQIgkLQcHKQVqasQ5uwwKQY0xljVoavfSU1YkwiZfntcKJvlDK0JkrYwmJcdLCqheJwfdvjxmzVqiSDMgZhJ3IPoCeAODRva5xyngEi9vplGuTYfbqnBJZYpBIG0n8vlqv9LKNRp9PVJ+0Nn66TJnXvIdEmTj9IMvCyV5AKt8y3u4Bbjbp9Lw=="

--- a/.github/workflows/serverlessDeploy.yml
+++ b/.github/workflows/serverlessDeploy.yml
@@ -27,7 +27,16 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
+      - name: Build dev .env.vault
+        if: github.ref_name == 'dev'
+        run: cp .env.vault.dev .env.vault
+
+      - name: Build prod .env.vault
+        if: github.ref_name == 'main'
+        run: cp .env.vault.prod .env.vault
+
       - run: npm ci
+
       - name: serverless deploy
         uses: serverless/github-action@v3.2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,3 @@ dist
 !.env.project
 !.env.vault.dev
 !.env.vault.prod
-
-
-!.env.vault

--- a/.gitignore
+++ b/.gitignore
@@ -141,5 +141,8 @@ dist
 .env*
 .flaskenv*
 !.env.project
-!.env.vault
+!.env.vault.dev
+!.env.vault.prod
 
+
+!.env.vault

--- a/serverless.ts
+++ b/serverless.ts
@@ -21,7 +21,7 @@ const serverlessConfiguration: AWS = {
   provider: {
     name: 'aws',
     runtime: 'nodejs20.x',
-    stage: 'dev',
+    stage: process.env.STAGE,
     apiGateway: {
       minimumCompressionSize: 1024,
       shouldStartNameWithService: true,


### PR DESCRIPTION
Added `STAGE` to .env for specifying dev/prod stage in serverless. Resolves #35 

Replaced `.env.vault` with `.env.vault.dev` and `.env.vault.prod`. The deploy workflow will build the appropriate .env.vault file based on branch name before deploying. This ensures our code is consistent across all branches and prevents any merge conflicts between dev and main.