### PR TITLE
feat(forgotPassword): use links and handle existing token records

### DIFF
--- a/tests/forgot-password.test.ts
+++ b/tests/forgot-password.test.ts
@@ -20,7 +20,7 @@ jest.mock('../src/util', () => ({
       disconnect: jest.fn(),
       getCollection: jest.fn().mockReturnValue({
         findOne: jest.fn().mockReturnValueOnce(null).mockReturnValue({ email: 'test@test.org' }),
-        insertOne: jest.fn().mockReturnValue({ insertedId: 'someId' }),
+        findOneAndUpdate: jest.fn().mockReturnValue({ insertedId: 'someId' }),
       }),
     }),
   },


### PR DESCRIPTION
Refactored the forgot password endpoint to send user a link with the reset token instead of a code. Also added handling for existing token records to ensure only one entry is in the database.