### PR TITLE
feat: user created and registered times 

### DIFF
--- a/src/functions/resume/handler.ts
+++ b/src/functions/resume/handler.ts
@@ -30,16 +30,16 @@ const resume: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (event) 
           url: presignedUrl,
           hasUploaded: true,
         }),
-      }
+      };
     } else {
-        return {
-          statusCode: 200,
-          body: JSON.stringify({
-            message: 'Upload the resume through the generated URL. (Use "PUT" method)',
-            url: presignedUrl,
-            hasUploaded: false,
-          }),
-        };
+      return {
+        statusCode: 200,
+        body: JSON.stringify({
+          message: 'Upload the resume through the generated URL. (Use "PUT" method)',
+          url: presignedUrl,
+          hasUploaded: false,
+        }),
+      };
     }
   } catch (error) {
     console.error('Error uploading resume', error);

--- a/tests/resume.test.ts
+++ b/tests/resume.test.ts
@@ -4,6 +4,7 @@ import { createEvent, mockContext } from './helper';
 jest.mock('../src/util', () => ({
   validateToken: jest.fn().mockReturnValueOnce(false).mockReturnValue(true),
   generatePresignedUrl: jest.fn().mockReturnValue('presigned-url'),
+  checkIfFileExists: jest.fn().mockReturnValueOnce(true).mockReturnValue(false),
 }));
 
 describe('/resume tests', () => {
@@ -27,11 +28,21 @@ describe('/resume tests', () => {
     expect(JSON.parse(res.body).message).toBe('Unauthorized');
   });
 
+  it('resume already submitted once before', async () => {
+    const mockEvent = createEvent(userData, path, httpMethod);
+
+    const res = await main(mockEvent, mockContext, mockCallback);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).hasUploaded).toBe(true);
+    expect(JSON.parse(res.body).url).toBe('presigned-url');
+  });
+
   it('success case, return a presigned url', async () => {
     const mockEvent = createEvent(userData, path, httpMethod);
 
     const res = await main(mockEvent, mockContext, mockCallback);
     expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).hasUploaded).toBe(false);
     expect(JSON.parse(res.body).url).toBe('presigned-url');
   });
 });

--- a/tests/waiver.test.ts
+++ b/tests/waiver.test.ts
@@ -38,6 +38,7 @@ describe('/waiver tests', () => {
     const res = await main(mockEvent, mockContext, mockCallback);
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).message).toBe('You already submitted a waiver');
+    expect(JSON.parse(res.body).hasUploaded).toBe(true);
   });
 
   it('success case, return a presigned url', async () => {
@@ -47,5 +48,6 @@ describe('/waiver tests', () => {
     const res = await main(mockEvent, mockContext, mockCallback);
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body).url).toBe('presigned-url');
+    expect(JSON.parse(res.body).hasUploaded).toBe(false);
   });
 });


### PR DESCRIPTION
- Added props in the user database for storing `created_at` ISO date-time strings upon creating a new account
- Also added a new prop called `registered_at` ISO date-time string when a user registers for the hackathon