### PR TITLE
hotfix: remove requirements in validateUpdates

### DIFF
--- a/src/functions/create/schema.ts
+++ b/src/functions/create/schema.ts
@@ -3,7 +3,6 @@ export default {
   properties: {
     email: { type: 'string', format: 'email' },
     password: { type: 'string' },
-    link: { type: 'string' },
     github: { type: 'string' },
     major: { type: 'string' },
     short_answer: { type: 'string' },
@@ -12,7 +11,7 @@ export default {
     last_name: { type: 'string' },
     dietary_restrictions: { type: 'string' },
     special_needs: { type: 'string' },
-    date_of_birth: { type: 'string' },
+    age: { type: 'string' },
     school: { type: 'string' },
     grad_year: { type: 'string' },
     gender: { type: 'string' },

--- a/src/functions/update/handler.ts
+++ b/src/functions/update/handler.ts
@@ -148,7 +148,6 @@ function validateUpdates(updates: Updates, registrationStatus?: string, user?: W
           [
             'email',
             'password',
-            'link',
             'github',
             'major',
             'short_answer',
@@ -157,7 +156,6 @@ function validateUpdates(updates: Updates, registrationStatus?: string, user?: W
             'last_name',
             'dietary_restrictions',
             'special_needs',
-            'date_of_birth',
             'school',
             'grad_year',
             'gender',


### PR DESCRIPTION
- Remove the `link` and `date_of_birth` requirements in `validateUpdates` function in `update` endpoint. 
- Change `date_of_birth` in `/create` endpoint request body to 'age'.