### PR TITLE
Interest form ux

### DIFF
--- a/src/functions/create/handler.ts
+++ b/src/functions/create/handler.ts
@@ -59,10 +59,12 @@ const create: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (event) 
         }),
       };
     }
-    // Check if interest form exists, if so retrieve data from it
+    // Check if interest form exists, if so retrieve data from the most recent submission
     const interestForms = db.getCollection('interest-forms');
-    const interestFormsData = await interestForms.findOne({ email: uEmail });
-
+    const interestFormsData = await interestForms.findOne(
+      { email: uEmail },
+      { sort: { submittedAt: -1 } }
+    );
     const doc = {
       email: uEmail,
       email_verified: false,

--- a/src/functions/create/handler.ts
+++ b/src/functions/create/handler.ts
@@ -93,6 +93,7 @@ const create: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (event) 
       level_of_study: interestFormsData?.levelOfStudy ?? event.body.level_of_study ?? '',
       ethnicity: event.body.ethnicity ?? '',
       phone_number: interestFormsData?.phoneNumber ?? event.body.phone_number ?? '',
+      country_of_residence: interestFormsData?.countryOfResidence ?? event.body.country_of_residence ?? '',
       registration_status: 'unregistered',
       day_of: {
         checkIn: false,

--- a/src/functions/create/handler.ts
+++ b/src/functions/create/handler.ts
@@ -59,6 +59,9 @@ const create: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (event) 
         }),
       };
     }
+    // Check if interest form exists, if so retrieve data from it
+    const interestForms = db.getCollection('interest-forms');
+    const interestFormsData = await interestForms.findOne({ email: uEmail });
 
     const doc = {
       email: uEmail,
@@ -78,17 +81,18 @@ const create: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (event) 
       major: event.body.major ?? '',
       short_answer: event.body.short_answer ?? '',
       shirt_size: event.body.shirt_size ?? '',
-      first_name: event.body.first_name ?? '',
-      last_name: event.body.last_name ?? '',
+      first_name: event.body.first_name ?? interestFormsData?.firstName ?? '',
+      last_name: event.body.last_name ?? interestFormsData?.lastName ?? '',
+      age: interestFormsData?.age?.toString() ?? event.body.age ?? '',
       dietary_restrictions: event.body.dietary_restrictions ?? '',
       special_needs: event.body.special_needs ?? '',
       date_of_birth: event.body.date_of_birth ?? '',
-      school: event.body.school ?? '',
+      school: interestFormsData?.school ?? event.body.school ?? '',
       grad_year: event.body.grad_year ?? '',
       gender: event.body.gender ?? '',
-      level_of_study: event.body.level_of_study ?? '',
+      level_of_study: interestFormsData?.levelOfStudy ?? event.body.level_of_study ?? '',
       ethnicity: event.body.ethnicity ?? '',
-      phone_number: event.body.phone_number ?? '',
+      phone_number: interestFormsData?.phoneNumber ?? event.body.phone_number ?? '',
       registration_status: 'unregistered',
       day_of: {
         checkIn: false,

--- a/src/functions/interest-form/handler.ts
+++ b/src/functions/interest-form/handler.ts
@@ -59,6 +59,7 @@ const submitInterestForm: ValidatedEventAPIGatewayProxyEvent<typeof schema> = as
       mlh_code_of_conduct,
       mlh_privacy_policy,
       mlh_terms_and_conditions,
+      submittedAt: new Date().toISOString(),
     };
 
     const result = await interestFormsCollection.insertOne(docToInsert);


### PR DESCRIPTION
- Interest forms now track date and time submitted
- If there is an interest form and a user decides to create an account, that interest form data will be pulled in.
  - Fields include:
    -  age
    - phone number
    - school
    - level of study
    - country of residence
  - Note: First and Last names are taken at the time of account creation. E.g. if a user has a different name on the interest form than the one at the signup page, the account will take the one at signup.
 - If there are multiple interest forms, it will take the most recent one
 
 TODO: Update documentation 
