### PR TITLE
feat(teams/read): return invited users

### DIFF
--- a/src/functions/teams/read/handler.ts
+++ b/src/functions/teams/read/handler.ts
@@ -108,6 +108,11 @@ const teamsRead: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (even
       };
     }
 
+    // Fetch team's pending invites (if any)
+    const pendingInviteUsers = await users
+      .find({ 'team_info.pending_invites.team_id': teamId }, { projection: { email: 1, _id: 0 } })
+      .toArray();
+
     // Return team data
     return {
       statusCode: 200,
@@ -115,6 +120,7 @@ const teamsRead: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (even
         statusCode: 200,
         message: 'Successfully read team',
         team,
+        invitedUsers: pendingInviteUsers.map((user) => user.email),
       }),
     };
   } catch (error) {


### PR DESCRIPTION
Teams read endpoint returns `invitedUsers` (array of emails for users with pending team invite) along with the team data. This will allow frontend to display a team's pending invites in the leader's dashboard for review/removal.