### PR TITLE
Unregistered teammates bug

### DIFF
--- a/src/functions/teams/create/handler.ts
+++ b/src/functions/teams/create/handler.ts
@@ -128,13 +128,10 @@ const teamsCreate: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (ev
 
     for (const email of memberEmails) {
       const user = await users.findOne({ email: email });
-      if (!user) 
-        invalidEmails.push(email);
-       else if (user.confirmed_team === true) 
-        emailsAlreadyInTeams.push(email);
-       else if (!validStatesForTeamCreation.includes(user.registration_status)) 
+      if (!user) invalidEmails.push(email);
+      else if (user.confirmed_team === true) emailsAlreadyInTeams.push(email);
+      else if (!validStatesForTeamCreation.includes(user.registration_status))
         emailsWithInvalidStatus.push({ email, status: user.registration_status });
-      
     }
 
     // Return errors if any validation failed


### PR DESCRIPTION
Added registration check. If user is in the `'registered', 'confirmation', or 'coming'` state, team creation will work. Any other state will fail